### PR TITLE
Update graphql-java to 14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ configurations {
 }
 
 dependencies {
-  compile 'com.graphql-java:graphql-java:13.0'
+  compile 'com.graphql-java:graphql-java:14.0'
   compile 'com.google.protobuf:protobuf-java:3.11.1'
   compile 'com.google.code.gson:gson:2.0'
 

--- a/src/main/java/com/braintreepayments/apollo_tracing_uploader/TracingUploadInstrumentationState.java
+++ b/src/main/java/com/braintreepayments/apollo_tracing_uploader/TracingUploadInstrumentationState.java
@@ -24,6 +24,7 @@ import graphql.execution.instrumentation.parameters.InstrumentationExecutionPara
 import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
 import graphql.language.AstPrinter;
 import graphql.language.AstSignature;
+import graphql.schema.GraphQLTypeUtil;
 import mdg.engine.proto.Reports;
 
 public class TracingUploadInstrumentationState implements InstrumentationState {
@@ -121,7 +122,7 @@ public class TracingUploadInstrumentationState implements InstrumentationState {
       path.getChild(rootNode)
         .setOriginalFieldName(stepInfo.getFieldDefinition().getName())
         .setType(stepInfo.simplePrint())
-        .setParentType(stepInfo.getParent().getUnwrappedNonNullType().getName())
+        .setParentType(GraphQLTypeUtil.simplePrint(stepInfo.getParent().getUnwrappedNonNullType()))
         .setStartTime(offsetNs)
         .setEndTime(offsetNs + durationNs);
     });


### PR DESCRIPTION
Updates the [graphql-java](https://github.com/graphql-java/graphql-java) library from 13.0 to 14.0.

Partially addresses issue https://github.com/braintree/apollo-tracing-uploader-java/issues/5.