### PR TITLE
Fix contention while constructing root node

### DIFF
--- a/src/main/java/com/braintreepayments/apollo_tracing_uploader/TracingUploadInstrumentationState.java
+++ b/src/main/java/com/braintreepayments/apollo_tracing_uploader/TracingUploadInstrumentationState.java
@@ -34,7 +34,7 @@ public class TracingUploadInstrumentationState implements InstrumentationState {
   private final BiConsumer<Reports.Trace.Builder, Object> customizeTrace;
   private final VariablesSanitizer sanitizeVariables;
   private final Reports.Trace.Builder proto;
-  private final ConcurrentHashMap<NodePath, Reports.Trace.Node> nodePathsToNodes;
+  private final Map<NodePath, Reports.Trace.Node> nodePathsToNodes;
   private final long startRequestNs;
   private Object context;
   public final boolean noop;

--- a/src/test/java/integration/EndToEndTest.java
+++ b/src/test/java/integration/EndToEndTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import com.braintreepayments.apollo_tracing_uploader.TracingUploadInstrumentation;
 import com.braintreepayments.apollo_tracing_uploader.VariablesSanitizer;
@@ -172,8 +173,8 @@ public class EndToEndTest {
     assertEquals(0, usersChild.getErrorCount());
     assertEquals(2, usersChild.getChildCount());
 
-    assertEquals(0, usersChild.getChild(0).getIndex());
-    assertEquals(1, usersChild.getChild(1).getIndex());
+    assertEquals(Arrays.asList(0, 1),
+                 usersChild.getChildList().stream().map(Reports.Trace.Node::getIndex).sorted().collect(Collectors.toList()));
 
     usersChild.getChildList().forEach(idIndexChild -> {
       assertEquals(1, idIndexChild.getChildCount());


### PR DESCRIPTION
Constructing the full root node was causing contention while adding children in each field / call to `beginFieldFetch`. Instrumentation will now only build the full root node on execution result.

Resolves https://github.com/braintree/apollo-tracing-uploader-java/issues/3
Resolves https://github.com/braintree/apollo-tracing-uploader-java/issues/4