### PR TITLE
Upgrade graphql-java to 17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,13 @@ configurations {
 }
 
 dependencies {
-  compile 'com.graphql-java:graphql-java:16.1'
+  compile 'com.graphql-java:graphql-java:17.1'
   compile 'com.google.protobuf:protobuf-java:3.11.1'
   compile 'com.google.code.gson:gson:2.0'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:3.2.0'
-  testCompile 'com.graphql-java-kickstart:graphql-java-tools:11.0.0'
+  testCompile 'com.graphql-java-kickstart:graphql-java-tools:11.1.0'
 }
 
 protobuf {

--- a/src/main/java/com/braintreepayments/apollo_tracing_uploader/TracingUploadInstrumentation.java
+++ b/src/main/java/com/braintreepayments/apollo_tracing_uploader/TracingUploadInstrumentation.java
@@ -131,7 +131,9 @@ public class TracingUploadInstrumentation extends SimpleInstrumentation {
      *                      context object. This should be used to set fields such as `clientName`, `clientVersion`, and
      *                      details about the HTTP request.
      * @return {@link Builder}
+     * @deprecated Deprecated in graphql-java, use {@link #customizeTraceGraphQLContext} instead.
      */
+    @Deprecated
     public Builder customizeTrace(BiConsumer<Reports.Trace.Builder, Object> traceConsumer) {
       this._customizeTrace = traceConsumer;
       return this;

--- a/src/main/java/com/braintreepayments/apollo_tracing_uploader/TracingUploadInstrumentationState.java
+++ b/src/main/java/com/braintreepayments/apollo_tracing_uploader/TracingUploadInstrumentationState.java
@@ -60,6 +60,7 @@ public class TracingUploadInstrumentationState implements InstrumentationState {
   }
 
   public ExecutionInput instrumentExecutionInput(ExecutionInput executionInput) {
+    //noinspection deprecation
     this.context = executionInput.getContext();
     this.graphQLContext = executionInput.getGraphQLContext();
 

--- a/src/test/java/integration/EndToEndTest.java
+++ b/src/test/java/integration/EndToEndTest.java
@@ -253,6 +253,7 @@ public class EndToEndTest {
   }
 
   private ExecutionInput getExecutionInput(String operation, String query, Map<String, Object> variables) {
+    //noinspection deprecation
     return ExecutionInput.newExecutionInput()
       .operationName(operation)
       .query(query)


### PR DESCRIPTION
* Add support for `GraphQLContext` instead of `Object` context objects, `Object` contexts are deprecated in graphql-java
* Upgrade graphql-java to 17.1